### PR TITLE
Change from application to library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+TODO

--- a/README.md
+++ b/README.md
@@ -4,23 +4,13 @@
 ![](https://img.shields.io/badge/VERSION-0.0.1-c6af16.svg?longCache=true&style=flat-square)
 ![](https://img.shields.io/badge/DOCUMENTED-SOON-darkorange.svg?longCache=true&style=flat-square)
 
-# Table of Contents
-
-### 1. [Motivation](#motivation)
-### 2. [API](#api)
-### 3. [The Future](#the-future)
-### 5. [License](#license)
-
-## Motivation
-
-**The ultimate goal of this project is to create a full-scale version of Fritzing in a Javascript environment.** In doing so, the hope is to construct a version of Fritzing which can be exposed to a wider array of the open source community.
 
 This project is a merge of several libraries:
 - https://github.com/fritzing/fzp-js
 - https://github.com/fritzing/fzz-js
 - https://github.com/karpawich/fzp2js
 
-As of right  now, the idea is to unify the functionality of those libraries into a single API with complete documentation of each Fritzing file format. While present documentation covers the main components of Fritzing files, there were specific components found in various files and the Fritzing source code which have yet to be publicly documented. This library aims to document those components so that they are supported in a Javascript environment.
+`fritzing-js` unifies the functionality of those libraries into a single API with complete documentation of each Fritzing file format.While present documentation covers the main components of Fritzing files, there were specific components found in various files and the Fritzing source code which have yet to be publicly documented. This library aims to document those components so that they are supported in a Javascript environment.
 
 
 ## API
@@ -182,15 +172,9 @@ Documention will come soon, but in the meantime you can inspect the source code 
 ## The Future
 
 - **Helper functions**
-- Publish to NPM
 - Documentation
 - Testing
-- Rendering
-  - Parts
-  - Sketches
-- Full-scale application
-  - Editing
-  - Autorouting
+- Publish to NPM
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-![FritzingJS](./logo.png?raw=true "FritzingJS")
-
+# Freetzing
 ![](https://img.shields.io/badge/CODE%20STYLE-STANDARD-d73526.svg?longCache=true&style=flat-square)
 ![](https://img.shields.io/badge/VERSION-0.0.1-c6af16.svg?longCache=true&style=flat-square)
 ![](https://img.shields.io/badge/DOCUMENTED-SOON-darkorange.svg?longCache=true&style=flat-square)
@@ -13,7 +12,7 @@
 
 ## Motivation
 
-**The ultimate goal of this project is to create a full-scale version of Fritzing in a Javascript environment.** In doing so, the hope is to construct a version of Fritzing which can be exposed to a wider array of the open source community.
+**The ultimate goal of this project is to create a highly modularized version of Fritzing in a Javascript environment.** In doing so, the hope is to construct a version of Fritzing which can be exposed to and updated by a wider array of the open source community.
 
 This project is a merge of several libraries:
 - https://github.com/fritzing/fzp-js
@@ -177,14 +176,15 @@ module.exports = {
 }
 ```
 
-Documention will come soon, but in the meantime you can inspect the source code of this library or read more about Fritzing file formats in the [Fritzing Wiki](https://github.com/fritzing/fritzing-app/wiki).
+Documention will come eventually, but in the meantime you can inspect the source code of this library or read more about Fritzing file formats in the [Fritzing Wiki](https://github.com/fritzing/fritzing-app/wiki).
 
 ## The Future
-
-- **Helper functions**
-- Publish to NPM
+- **Modularize Fritzing data models**
+- Conversion from old data (Sketches, Parts)
+- Helper functions (get, set, indexOf, remove, etc.)
 - Documentation
 - Testing
+- Publish libraries to NPM
 - Rendering
   - Parts
   - Sketches
@@ -194,7 +194,7 @@ Documention will come soon, but in the meantime you can inspect the source code 
 
 ## License
 
-`fritzing-js` is originally based upon the [Fritzing](https://github.com/fritzing/fritzing-app) CAD application.
+`freetzing` is originally based upon the [Fritzing](https://github.com/fritzing/fritzing-app) CAD application.
 
 ### **Thus, the project is also licensed under [GNU GPL v3](https://www.gnu.org/licenses/gpl-3.0.en.html).**
  You can find a copy of the license in the LICENSE file of this repository.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Freetzing
+![FritzingJS](./logo.png?raw=true "FritzingJS")
+
 ![](https://img.shields.io/badge/CODE%20STYLE-STANDARD-d73526.svg?longCache=true&style=flat-square)
 ![](https://img.shields.io/badge/VERSION-0.0.1-c6af16.svg?longCache=true&style=flat-square)
 ![](https://img.shields.io/badge/DOCUMENTED-SOON-darkorange.svg?longCache=true&style=flat-square)
@@ -12,7 +13,7 @@
 
 ## Motivation
 
-**The ultimate goal of this project is to create a highly modularized version of Fritzing in a Javascript environment.** In doing so, the hope is to construct a version of Fritzing which can be exposed to and updated by a wider array of the open source community.
+**The ultimate goal of this project is to create a full-scale version of Fritzing in a Javascript environment.** In doing so, the hope is to construct a version of Fritzing which can be exposed to a wider array of the open source community.
 
 This project is a merge of several libraries:
 - https://github.com/fritzing/fzp-js
@@ -176,15 +177,14 @@ module.exports = {
 }
 ```
 
-Documention will come eventually, but in the meantime you can inspect the source code of this library or read more about Fritzing file formats in the [Fritzing Wiki](https://github.com/fritzing/fritzing-app/wiki).
+Documention will come soon, but in the meantime you can inspect the source code of this library or read more about Fritzing file formats in the [Fritzing Wiki](https://github.com/fritzing/fritzing-app/wiki).
 
 ## The Future
-- **Modularize Fritzing data models**
-- Conversion from old data (Sketches, Parts)
-- Helper functions (get, set, indexOf, remove, etc.)
+
+- **Helper functions**
+- Publish to NPM
 - Documentation
 - Testing
-- Publish libraries to NPM
 - Rendering
   - Parts
   - Sketches
@@ -194,7 +194,7 @@ Documention will come eventually, but in the meantime you can inspect the source
 
 ## License
 
-`freetzing` is originally based upon the [Fritzing](https://github.com/fritzing/fritzing-app) CAD application.
+`fritzing-js` is originally based upon the [Fritzing](https://github.com/fritzing/fritzing-app) CAD application.
 
 ### **Thus, the project is also licensed under [GNU GPL v3](https://www.gnu.org/licenses/gpl-3.0.en.html).**
  You can find a copy of the license in the LICENSE file of this repository.


### PR DESCRIPTION
My original intention (as [my original pull request](https://github.com/fritzing/fritzing-js/pull/5) shows) was to start with this library for Fritzing data models in a Javascript environment and then expand that out into a full-scale Fritzing application built with Electron. That project now lives at https://github.com/freetzing/freetzing. This repository should only contain the source code for the original library.

I have updated the README in this pull request to reflect those changes, and will continue to work on documenting and testing this library to ensure its legitimacy.

@el-j Can we change the description of the library to "The Javascript library for Fritzing." I cannot change the description through a pull request.